### PR TITLE
Correct the known-good commit value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 include Makefile.conf
 
 ARCH:=$(shell uname -s)-$(shell uname -m)
-STABLE=c8c12b06a1150c004213619aa8f1b5d7748cfc84
+STABLE=c01c85ef098bb275d73965aa95d8fdbe0bf2cf18
 all: minigrace $(OTHER_MODULES) $(GRACE_MODULES:.grace=.gct) $(GRACE_MODULES:.grace=.gcn) sample-dialects
 
 REALSOURCEFILES = compiler.grace errormessages.grace util.grace ast.grace lexer.grace parser.grace genjs.grace genc.grace mgcollections.grace collections.grace interactive.grace xmodule.grace identifierresolution.grace genjson.grace gUnit.grace

--- a/tools/git-calculate-generation
+++ b/tools/git-calculate-generation
@@ -38,9 +38,9 @@ findgen() {
     then
         echo 2037
         return 0
-    elif [ "c8c12b06a1150c004213619aa8f1b5d7748cfc84" = $h ]
+    elif [ "c01c85ef098bb275d73965aa95d8fdbe0bf2cf18" = $h ]
     then
-        echo 2105
+        echo 2104
         return 0
     fi
     if [ "$KNOWN" ] && [ "${known[$h]}" ]


### PR DESCRIPTION
The `STABLE` variable in the Makefile and the generation tooling pointed to the commit after the one which was the latest known-good point. This commit points them back to the appropriate commit, with the right version number.

Note that this requires correcting the installation of the dist on the pdx server, removing 0.0.9.2105 and replacing it with a build of 0.0.9.2014. Following this, the build process with tarball-bootstrap should work correctly again.
