### PR TITLE
Adjust JS test build to work without installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: 
+language:
   - c
   - node_js
 node_js:
@@ -9,5 +9,4 @@ before_script:
   - git fetch --unshallow
 script:
   - ./tools/tarball-bootstrap -a && make && make test
-  - sudo make install
   - make js && make test.js

--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,10 @@ test.js.compile:
 	@echo "compiling tests to JavaScript"
 	@cd js/tests; ls *_test.grace | grep -v "fail" | sed 's/^t\([0-9]*\)_.*/& \1/' | while read -r fileName num; do echo "$$num \c"; ../..//minigrace --target js $${fileName}; done && echo "tests compiled."
 
-test.js: js/StandardPrelude.js js/collectionsPrelude.js js/collections.js js/gUnit.js sample-dialects
-	(cd js/tests; rm requireTypes.{gso,gct} && ln -s  ../sample/dialects/requireTypes.{gso,gct} .; ./harness ../../minigrace . "")
+test.js: js/StandardPrelude.js js/collectionsPrelude.js js/collections.js js/gUnit.js js/sample/dialects/requireTypes.js
+	ln -fs ../sample/dialects/requireTypes.gso ../sample/dialects/requireTypes.js js/tests
+	npm install performance-now
+	js/tests/harness ../../minigrace js/tests ""
 
 js/index.html: js/index.in.html js/ace js/minigrace.js js/tests
 	@echo Generating index.html from index.in.html...

--- a/js/tests/grace-node
+++ b/js/tests/grace-node
@@ -225,8 +225,13 @@ if (! graceModulePath) {
     }
 }
 var pathdirs = graceModulePath.split(path.delimiter);
+
 if ( pathdirs.indexOf("./") === -1 ) {
     pathdirs.push("./");
+}
+
+if ( pathdirs.indexOf("../") === -1 ) {
+    pathdirs.push("../");
 }
 
 MiniGrace.prototype.loadModule = function(moduleName) {


### PR DESCRIPTION
The build process for the JavaScript tests relied on the system being
installed in order to resolve paths appropriately. Now the tests can be
run locally.

Note that Travis passes again with this change.
