### PR TITLE
Correct the hashbang for tools/validate-commit-message.

### DIFF
--- a/tools/validate-commit-message
+++ b/tools/validate-commit-message
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Enforce that the commit message is correctly formatted.
 # It must:


### PR DESCRIPTION
As the script is not POSIX compliant, it must use bash.