### PR TITLE
Implement a 'ryanWeb' target to build grace-web-editor.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -320,8 +320,9 @@ rtobjectdraw.gcn rtobjectdraw.gso:
 	@echo "Can't build $@; no C version of dom module"
 
 ryanWeb: js grace-web-editor/scripts/setup.js $(filter-out js/tabs.js,$(filter %.js,$(WEBFILES)))
-	rsync -a -l -z --delete grace-web-editor/ ~/public_html/minigrace/exp/
-	rsync -a -l -z --delete $(filter-out js/tabs.js,$(filter %.js,$(WEBFILES))) ~/public_html/minigrace/exp/js/
+	@[ -n "$(SERVER)" ] || { echo "Please set the SERVER environment variable to something like user@machine" && false; }
+	rsync -a -l -z --delete grace-web-editor/ $(SERVER):public_html/minigrace/exp/
+	rsync -a -l -z --delete $(filter-out js/tabs.js,$(filter %.js,$(WEBFILES))) $(SERVER):public_html/minigrace/exp/js/
 
 sample-dialects: minigrace
 	$(MAKE) -C sample/dialects VERBOSITY=$(VERBOSITY)

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,7 @@ clean:
 	rm -f js/minigrace.js
 	cd c && rm -f *.gcn *.gct *.c *.h *.grace minigrace unicode.gso gracelib.o
 	rm -f minigrace.gco minigrace *.js
+	rm -fr grace-web-editor
 	cd stubs && rm -f *.gct *gcn *.gso *js *.c
 	cd sample/dialects && $(MAKE)  clean
 	cd js/sample/graphics && $(MAKE) clean


### PR DESCRIPTION
This rule clones, prepares and installs the newer editor.